### PR TITLE
fix: Fixes #18 Implement dynamic message rendering in ChatScreen and ChatHistory components

### DIFF
--- a/frontend/src/ChatHistory.css
+++ b/frontend/src/ChatHistory.css
@@ -1,15 +1,13 @@
 #chat-history {
   overflow-x: hidden;
+  overflow-y: auto;
   padding: 0.5rem;
   border-radius: 5px;
   margin-top: 5px;
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-#chat-bubble-container {
-  display: flex;
-  flex-direction: row;
-  align-items: top;
-  padding-top: 5px;
-  padding-bottom: 5px;
-}
+

--- a/frontend/src/ChatHistory.jsx
+++ b/frontend/src/ChatHistory.jsx
@@ -2,13 +2,16 @@ import "./ChatHistory.css";
 import IncomingChatBubble from "./IncomingChatBubble";
 import OutgoingChatBubble from "./OutgoingChatBubble";
 
-function ChatHistory() {
+function ChatHistory({ messages }) {
   return (
     <div id="chat-history">
-      
-      <OutgoingChatBubble message="Hey!" />
-      <IncomingChatBubble message="I am Askage!!" />
-
+      {messages.map((msg, index) =>
+        msg.type === "outgoing" ? (
+          <OutgoingChatBubble key={index} message={msg.content} />
+        ) : (
+          <IncomingChatBubble key={index} message={msg.content} />
+        )
+      )}
     </div>
   );
 }

--- a/frontend/src/ChatScreen.css
+++ b/frontend/src/ChatScreen.css
@@ -1,9 +1,12 @@
 #chat-screen {
-    display: block;
     width: 300px;
     height: 400px;
     padding: 10px;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
-}
+    background-color: #121212;
+    color: white;
+    font-family: 'Segoe UI', sans-serif;
+  }
+  

--- a/frontend/src/ChatScreen.jsx
+++ b/frontend/src/ChatScreen.jsx
@@ -1,13 +1,29 @@
-import "./ChatScreen.css";
+import { useState, useEffect, useRef } from "react";
 import Heading from "./Heading";
-import MessageBox from "./MessageBox";
 import ChatHistory from "./ChatHistory";
+import MessageBox from "./MessageBox";
+import "./ChatScreen.css";
 
 function ChatScreen() {
+  const [messages, setMessages] = useState([]);
+  const initialized = useRef(false);
+
+  const addMessage = (type, content) => {
+    setMessages(prev => [...prev, { type, content }]);
+  };
+
+  useEffect(() => {
+    if (!initialized.current) {
+      addMessage("outgoing", "Hey!");
+      addMessage("incoming", "Askage this side!");
+      initialized.current = true;
+    }
+  }, []);
+
   return (
     <div id="chat-screen">
       <Heading />
-      <ChatHistory />
+      <ChatHistory messages={messages} />
       <MessageBox />
     </div>
   );

--- a/frontend/src/IncomingChatBubble.css
+++ b/frontend/src/IncomingChatBubble.css
@@ -1,3 +1,13 @@
-#incoming-chat-bubble {
-  display: block;
+.chat-bubble-container.incoming {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.incoming-chat-bubble {
+  background-color: #2a2a2a;
+  color: white;
+  padding: 10px 14px;
+  border-radius: 16px 16px 16px 4px;
+  max-width: 70%;
+  word-wrap: break-word;
 }

--- a/frontend/src/IncomingChatBubble.jsx
+++ b/frontend/src/IncomingChatBubble.jsx
@@ -2,8 +2,8 @@ import "./IncomingChatBubble.css";
 
 function IncomingChatBubble({ message }) {
   return (
-    <div id="chat-bubble-container" style={{ justifyContent: "left" }}>
-      <div id="incoming-chat-bubble">{message}</div>
+    <div className="chat-bubble-container incoming">
+      <div className="incoming-chat-bubble">{message}</div>
     </div>
   );
 }

--- a/frontend/src/OutgoingChatBubble.css
+++ b/frontend/src/OutgoingChatBubble.css
@@ -1,3 +1,13 @@
-#outgoing-chat-bubble {
-  display: block;
+.chat-bubble-container.outgoing {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.outgoing-chat-bubble {
+  background-color: #007bff;
+  color: white;
+  padding: 10px 14px;
+  border-radius: 16px 16px 4px 16px;
+  max-width: 70%;
+  word-wrap: break-word;
 }

--- a/frontend/src/OutgoingChatBubble.jsx
+++ b/frontend/src/OutgoingChatBubble.jsx
@@ -2,8 +2,8 @@ import "./OutgoingChatBubble.css";
 
 function OutgoingChatBubble({ message }) {
   return (
-    <div id="chat-bubble-container" style={{ justifyContent: "right" }}>
-      <div id="outgoing-chat-bubble">{message}</div>
+    <div className="chat-bubble-container outgoing">
+      <div className="outgoing-chat-bubble">{message}</div>
     </div>
   );
 }


### PR DESCRIPTION
This PR sets up dynamic chat rendering as per Issue #18:

Messages are stored in state and added using a reusable addMessage() function.
Sample messages ("Hey!" and "Askage this side!") are added on initial render.
ChatHistory receives the message list via props and renders bubbles based on type.
Alignment and styling fixed for clean left/right message display.