### PR TITLE
#62 - Add Dockerfile for Flask server

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt
+
+ENV ENV=production
+
+CMD ["gunicorn", "server:app", "--bind", "0.0.0.0:80", "--workers", "1", "--threads", "2"]


### PR DESCRIPTION
This PR adds a Dockerfile to run the Flask app using Gunicorn with 1 worker and 2 threads on port 80 inside the container, and maps it to port 8000 externally.